### PR TITLE
add useCustomSearch option to prevent from overwriting __search metho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ To use the plugin with Material v5 or v6 projects:
     ```
     A delay of 100 ms worked with a search index of 24 MB ([prebuilt index](https://www.mkdocs.org/user-guide/configuration/#prebuild_index)).<br>Note that the `promise_delay` setting has a negative effect on performance (loading time will be increased).
 
+**Note:** If you [customize search](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#custom-search) settings, such as [query transformation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#query-transformation), add the `useCustomSearch` setting:
+
+```yaml
+  - localsearch:
+      useCustomSearch: true
+```
+
+Example of `theme/main.html` file is: 
+
+```html
+{% extends "base.html" %}
+{% block config %}
+{{ super() }}
+{% if "localsearch" in config["plugins"] %}
+<script src="{{ 'assets/javascripts/iframe-worker.js' | url }}"></script>
+<script src="{{ 'search/search_index.js' | url }}"></script>
+{% endif %}
+<script src="https://cdn.jsdelivr.net/npm/tiny-segmenter@0.2.0/dist/tiny-segmenter-0.2.0.min.js"></script>
+<script>
+var __search = {
+    index: Promise.resolve(local_index),
+    transform: function(query) {
+        var segmenter = new TinySegmenter();
+        var segs = segmenter.segment(query);
+        var newQuery = segs.join(" ");
+        return newQuery;
+    }
+}
+</script>
+{% endblock %}
+```
+
+This setting is for Japanese "ja-jp" full-text search.
+
 ## Installation (Material v4)
 
 To use the plugin with Material v4 projects:

--- a/mkdocs_localsearch_plugin/plugin.py
+++ b/mkdocs_localsearch_plugin/plugin.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import mkdocs
 from mkdocs import utils
 from mkdocs.config import config_options, Config
 from mkdocs.plugins import BasePlugin
@@ -16,7 +17,10 @@ class LocalSearchPlugin(BasePlugin):
             # Open JSON search index file
             f = open(json_output_path,"r")
             # Modify file to provide a Promise resolving with the contents of the search index
-            search_index = "const local_index = " + f.read() + "; var __search = { index: Promise.resolve(local_index) }"
+            if self.config.get('useCustomSearch', False):
+                search_index = "const local_index = " + f.read()
+            else:
+                search_index = "const local_index = " + f.read() + "; var __search = { index: Promise.resolve(local_index) }"
             # Write to JSON file and rename JSON to JS
             utils.write_file(search_index.encode('utf-8'), json_output_path)
             f.close()


### PR DESCRIPTION
I customized search query transformation because it is needed for Japanese full-text search. Japanese does not use any spaces between words, so splitting sentence to words (segmentation) is not an easy job. Segmentation result strongly depends on segmentation library. MkDocs Material use Lunr for searching, and Lunr use TinySegmenter for Japanese segmentation. So, we need to use TinySegmenter for search query segmentation. That is why I made issue and I made pull request. Please review my pull request and I hope you accept my proposal. Thank you for your useful plug-in. The previous my pull request was on my wrong branch, so I created new pull request again on my feature/#13 branch. And I am sorry for bothering you. 