### PR TITLE
Prevent error on mkdocs build --dirty (#15)

### DIFF
--- a/mkdocs_localsearch_plugin/plugin.py
+++ b/mkdocs_localsearch_plugin/plugin.py
@@ -20,6 +20,8 @@ class LocalSearchPlugin(BasePlugin):
             # Write to JSON file and rename JSON to JS
             utils.write_file(search_index.encode('utf-8'), json_output_path)
             f.close()
+            if os.path.exists(js_output_path):
+                os.remove(js_output_path)
             os.rename(json_output_path, js_output_path)
         else:
             log.warning('localsearch: Missing search plugin. You must add both search and localsearch to the list of plugins in mkdocs.yml.')

--- a/mkdocs_localsearch_plugin/plugin.py
+++ b/mkdocs_localsearch_plugin/plugin.py
@@ -20,8 +20,6 @@ class LocalSearchPlugin(BasePlugin):
             # Write to JSON file and rename JSON to JS
             utils.write_file(search_index.encode('utf-8'), json_output_path)
             f.close()
-            if os.path.exists(js_output_path):
-                os.remove(js_output_path)
-            os.rename(json_output_path, js_output_path)
+            os.replace(json_output_path, js_output_path)
         else:
             log.warning('localsearch: Missing search plugin. You must add both search and localsearch to the list of plugins in mkdocs.yml.')


### PR DESCRIPTION
Mkdocs has an option for fast build (--dirty), which do not clear existing files in site/ directory. My target site is rather large, so ```mkdocs build –dirty``` is preferable for fast development. Thank you for your nice useful plug-in. I am sorry for bothering you about my pull request. I appreciate so much if you accept this.